### PR TITLE
Explicitly add circularising links to unitig GFA

### DIFF
--- a/asm.c
+++ b/asm.c
@@ -82,6 +82,10 @@ void ma_ug_print(const ma_ug_t *ug, const sdict_t *d, const ma_sub_t *sub, FILE 
 		ma_utg_t *p = &ug->u.a[i];
 		sprintf(name, "utg%.6d%c", i + 1, "lc"[p->circ]);
 		fprintf(fp, "S\t%s\t%s\tLN:i:%d\n", name, p->s? p->s : "*", p->len);
+		if (p->circ) {  // make circularising links (both forward and reverse directions) for circular unitigs
+			fprintf(fp, "L\t%s\t+\t%s\t+\t0M\n", name, name);
+			fprintf(fp, "L\t%s\t-\t%s\t-\t0M\n", name, name);
+		}
 		for (j = l = 0; j < p->n; l += (uint32_t)p->a[j++]) {
 			uint32_t x = p->a[j]>>33;
 			if (sub) fprintf(fp, "a\t%s\t%d\t%s:%d-%d\t%c\t%d\n", name, l, d->seq[x].name, sub[x].s + 1, sub[x].e, "+-"[p->a[j]>>32&1], (uint32_t)p->a[j]);


### PR DESCRIPTION
This is a small change to the unitig GFA output. Instead of just relying on the last character of the unitig name to indicate circularity (`l` for linear and `c` for circular), this change gives circular unitigs an explicit overlap-free link in the GFA file.

Before:
```
S       utg000030c      GGAACAAACTGCATTAATTC...TATCACCAGAAAAGACAGAT	LN:i:69013
a       utg000030c      0       0ab4d3ed-f533-4bfd-880c-fa1a0568443b:17-68951    +       3431
a       utg000030c      3431    1e81464e-9194-40f4-ba59-d29f9b1a7d65:33-68891    +       16745
a       utg000030c      20176   fb2dd196-c8bb-4770-b693-d02329c1dab2:1-67957     +       24
```

After:
```
S       utg000030c      GGAACAAACTGCATTAATTC...TATCACCAGAAAAGACAGAT	LN:i:69013
L       utg000030c      +       utg000030c      +       0M
L       utg000030c      -       utg000030c      -       0M
a       utg000030c      0       0ab4d3ed-f533-4bfd-880c-fa1a0568443b:17-68951    +       3431
a       utg000030c      3431    1e81464e-9194-40f4-ba59-d29f9b1a7d65:33-68891    +       16745
a       utg000030c      20176   fb2dd196-c8bb-4770-b693-d02329c1dab2:1-67957     +       24
```

This change is mainly to make miniasm assemblies for bacterial genomes (in which circular unitigs are common) display as circular when loaded in Bandage.

Thanks so much for this great tool (and all your others), and let me know if you have any questions!

Ryan